### PR TITLE
Reposition site copy for professional authority; fix footer and carousel

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,9 +10,9 @@
 
 title: iRodriguez
 description: >-
-  Isidro Rodriguez — Identity & Access engineer writing about secure automation
-  for small businesses. Enterprise IAM thinking applied to n8n, AI agents, and
-  SaaS sprawl.
+  Isidro Rodriguez, identity and access engineer. Writing on identity lifecycle,
+  authentication design, and building process automation that does not turn into
+  an unmanaged access path.
 author: Isidro Rodriguez
 url: "https://irodriguez.io"
 baseurl: ""

--- a/css/main.css
+++ b/css/main.css
@@ -459,11 +459,15 @@ em{
 .slide-arrow {
   position: absolute;
   display: flex;
-  bottom: 1rem;
+  align-items: center;
+  justify-content: center;
+  top: 50%;
+  transform: translateY(-50%);
   height: 4rem;
   width: 2rem;
   background-color: var(--BGcolor1);
   font-size: 3rem;
+  line-height: 1;
   padding: 0;
   cursor: pointer;
   opacity: 0.4;
@@ -477,14 +481,12 @@ em{
 }
 
 .arrow-prev {
-  left: 50%;
-  padding-left: 0.25rem;
+  left: 0;
   border-radius: 0 2rem 2rem 0;
 }
 
 .arrow-next {
-  right: 50%;
-  padding-left: 0.75rem;
+  right: 0;
   border-radius: 2rem 0 0 2rem;
 }
 
@@ -633,6 +635,10 @@ em{
 /*** Footer Section ***/
 
 footer{
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  gap: 1.5rem;
   text-align: center;
   margin: 2rem 0;
   position: relative;
@@ -653,7 +659,7 @@ footer img{
   position: absolute;
   margin: 0 auto;
   width: 100%;
-  top: 40%;
+  top: 35%;
   z-index: -1;
 }
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: null
-title: iRodriguez — Identity & Access · Secure Automation
+title: iRodriguez — Identity & Access Engineering
 permalink: /
 ---
 <!DOCTYPE html>
@@ -9,9 +9,9 @@ permalink: /
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1"/>
     <link rel="shortcut icon" href="img/logo-dark.png" type="image/x-icon">
-    <title>iRodriguez — Identity & Access · Secure Automation</title>
+    <title>iRodriguez — Identity & Access Engineering</title>
     <meta name="author" content="Isidro Rodriguez"/>
-    <meta name="description" content="Isidro Rodriguez — Identity & Access engineer writing about secure automation for small businesses. Enterprise IAM thinking applied to n8n, AI agents, and SaaS sprawl."/>
+    <meta name="description" content="Isidro Rodriguez, identity and access engineer. Writing on identity lifecycle, authentication design, and building process automation that does not turn into an unmanaged access path."/>
     <!-- CSS -->
     <link rel="stylesheet" href="css/main.css"/>
     <!-- JavaScript -->
@@ -74,10 +74,10 @@ permalink: /
         <img class="owner-pic border" alt="Isidro's picture" src="img/me.png">
         <article class="description">
           <h1>Isidro Rodríguez</h1>
-          <p>I've spent 19 years as a systems engineer and the last decade focused on Identity and Access Management — most recently administering Okta and building no-code automations at Remitly's scale.</p>
-          <p>Identity is where systems either hold together or quietly fall apart. The same automation that saves your team 20 hours a week is one forgotten API key or one over-permissioned service account away from being a headline.</p>
-          <p>Most small businesses are getting into AI and automation without anyone in the room asking the hard security questions. Enterprises pay people like me to ask those questions. Small businesses can't — and shouldn't have to.</p>
-          <p>I write about what enterprise IAM gets right, what small businesses can borrow from it, and how to build automations that survive both an audit and a breach.</p>
+          <p>Nineteen years as a systems engineer, the last decade in identity and access management. Day to day I work on corporate identity providers at enterprise scale: authentication policy, phishing-resistant factors, joiner-mover-leaver lifecycle, service accounts, and the automation that runs all of it. Okta Certified Professional.</p>
+          <p>Identity is where systems either hold together or quietly fall apart. The automation that saves a team twenty hours a week is one forgotten API key away from being the incident report.</p>
+          <p>Most of what I write starts from the same observation. Automation platforms and AI agents are being handed credentials faster than anyone is governing them. An n8n workflow with a stored token is a service account. A coding agent running under someone's session is an unmanaged identity. The IAM playbook already covers this. It just has not been pointed at it yet.</p>
+          <p>So that is what I write about: identity engineering, lifecycle automation, and the places where the two quietly go wrong.</p>
           <p><em>Strong opinions. Working code. No vendor cheerleading.</em></p>
         </article>
         <button class="linkedin glass">
@@ -88,39 +88,38 @@ permalink: /
       <section id="services">
         <article class="services-content">
           <h1>Expertise.</h1>
-          <p>Enterprise-grade thinking, sized for growing businesses. I help small and mid-sized teams figure out who has access to what, lock it down, and automate the boring work without opening the door to a breach. The frameworks come from the enterprise IAM world — PCI-DSS, HIPAA, GDPR, FISMA, Zero Trust, joiner-mover-leaver — but the recommendations are calibrated to what a 10-to-200-person company can actually execute.</p>
-          <p>The flagship offer — the Secure Identity Posture Assessment — is in development and launches Q4 2026. Until then, follow the writing and the open-source work below.</p>
+          <p>Where I spend my time. The through-line is identity: what can reach a system, how that access gets granted and taken away, and how much of it can be automated without losing the audit trail. The frameworks are the enterprise ones, least privilege and joiner-mover-leaver and Zero Trust, ISO 27001 and SOX and PCI DSS. The interesting problems are always further down, in the implementation.</p>
         </article>
-        <button class="slide-arrow arrow-next">&#8249;</button>
-        <button class="slide-arrow arrow-prev">&#8250;</button>
+        <button class="slide-arrow arrow-prev">&#8249;</button>
+        <button class="slide-arrow arrow-next">&#8250;</button>
         <ul class="slides-container glass">
           <li class="slide border">
             <img src="img/risk.svg">
             <div>
-              <h2>Secure Identity Posture Assessment <em>(Coming Q4 2026)</em></h2>
+              <h2>Identity Lifecycle and Governance</h2>
               <p>
-                <em>Find out who really has access to what — before you find out the wrong way.</em>
-                A short, practical audit of your business's identity setup: who can log in to what, where credentials live, what your automations can touch, and which 3 fixes would matter most. Delivered as a prioritized report you can act on. Built for businesses with 10–200 employees and growing SaaS sprawl.
+                <em>Joiner-mover-leaver as an engineering problem, not a ticket queue.</em>
+                Provisioning and deprovisioning over SCIM, access reviews that produce evidence instead of spreadsheets, and governance for the service accounts nobody remembers owning. Granting access is the easy half. The hard half is proving the removal actually happened, inside the window you promised the auditor.
               </p>
             </div>
           </li>
           <li class="slide border">
             <img src="img/cyber.svg">
             <div>
-              <h2>Identity & Access Strategy for Growing Businesses</h2>
+              <h2>Authentication and Access Design</h2>
               <p>
-                <em>Enterprise IAM thinking, sized to your business.</em>
-                The frameworks that enterprises use to manage who has access to what — joiner-mover-leaver, least privilege, Zero Trust — translated into the practical decisions a 30-person company needs to make. Strategy, not vendor pitches.
+                <em>Policy, factors, and privilege, in the order they have to happen.</em>
+                Authentication policy, phishing-resistant factors, privileged access, and the Zero Trust patterns from NIST 800-207 applied to environments that already exist and cannot stop working. Moving an entire workforce off passwords and SMS is less a technology decision than a sequencing one, and the sequence is where most rollouts stall.
               </p>
             </div>
           </li>
           <li class="slide border">
             <img src="img/appdev.svg">
             <div>
-              <h2>Secure Automation Builds <em>(n8n + AI)</em></h2>
+              <h2>Automation With an Identity Model <em>(n8n, Okta Workflows, AI agents)</em></h2>
               <p>
-                <em>Automate the boring work — without opening the door to a breach.</em>
-                Custom n8n and AI agent workflows designed with enterprise-grade security from day one: scoped credentials, audit logging, least-privilege service accounts, and rotation built in. The kind of automation that survives both an audit and a 3am incident.
+                <em>Every workflow holds a credential, which makes every workflow an identity.</em>
+                Process automation built with scoped credentials, rotation, and audit logging from the first version rather than the third. Treating a workflow as an identity is the whole difference between an automation and an access path nobody is watching, and it costs almost nothing when you do it at the start.
               </p>
             </div>
           </li>
@@ -128,7 +127,7 @@ permalink: /
       </section>
       <section id="articles">
         <h1>Perspectives.</h1>
-        <p>New writing on Identity & Access Management and secure automation is on the way. Below are earlier essays on cybersecurity fundamentals — NIST frameworks, threat landscapes, and the basics every growing business should understand before the IAM conversation starts.</p>
+        <p>Writing on identity engineering, lifecycle automation, and the security questions that get skipped when automation moves faster than governance. The earlier essays cover fundamentals, NIST CSF and the RMF and the eight domains, which are still the groundwork for everything after them.</p>
         <div class="article-grid">
           {% assign posts_en = site.posts | where: "lang", "en" %}
           {% for post in posts_en %}
@@ -144,7 +143,7 @@ permalink: /
       <section id="contact" class="contact-section glass">
         <div class="contact-intro">
           <h2 class="contact-title">Get in Touch.</h2>
-          <p class="contact-description">Reach out about IAM, secure automation, speaking, or collaboration. I read every message — replies on a best-effort basis.</p>
+          <p class="contact-description">Questions about identity engineering or automation, speaking and podcast invitations, or a note on something I wrote. I read everything and answer when I can.</p>
         </div>
         <form class="contact-form" action="https://api.web3forms.com/submit" method="POST">
           <input type="hidden" name="access_key" value="0930297a-ed42-4661-8532-7e6227a284f7"/>
@@ -159,10 +158,6 @@ permalink: /
             <div class="form-group">
               <label for="email" class="form-label">Email</label>
               <input id="email" name="email" class="form-input" placeholder="Your email" type="email"/>
-            </div>
-            <div class="form-group">
-              <label for="phone" class="form-label">Phone</label>
-              <input id="phone" name="phone" class="form-input" placeholder="+1 (234) 56789" type="text"/>
             </div>
             <div class="form-group">
               <label for="message" class="form-label">Message</label>

--- a/js/main.js
+++ b/js/main.js
@@ -100,16 +100,16 @@ let textArr = []
 
 if (Lang == "en-US") {
   textArr = [
-  "Enterprise automation, built secure by default.",
-  "Identity, secured. Workflows, automated.",
-  "Most automation breaks on security. I do the opposite.",
-  "Built for SMBs that can't afford to be insecure.",
+  "Access is a system. Design it like one.",
+  "Every workflow holds a credential. That makes it an identity.",
+  "Granting access is easy. Removing it is the test.",
+  "Identity engineering, and the automation around it.",
   ]
   }else { textArr = [
-  "Automatización empresarial, segura desde el primer día.",
-  "Identidad protegida. Flujos automatizados.",
-  "La mayoría de automatizaciones se rompen en la seguridad. Yo hago lo contrario.",
-  "Construido para PYMES que no pueden permitirse ser inseguras.",
+  "El acceso es un sistema. Diséñalo como tal.",
+  "Todo flujo guarda una credencial. Eso lo vuelve una identidad.",
+  "Dar acceso es fácil. Quitarlo es la prueba.",
+  "Ingeniería de identidad, y la automatización a su alrededor.",
   ]}
 
 let currentTextIndex = -1
@@ -189,17 +189,17 @@ const slide = document.querySelector(".slide");
 const prevButton = document.querySelector(".arrow-prev");
 const nextButton = document.querySelector(".arrow-next");
 
-nextButton.addEventListener("click", foward)
-                            
-function foward() {
+prevButton.addEventListener("click", backward)
+
+function backward() {
   const slideWidth = slide.clientWidth;
   slidesContainer.scrollLeft -= slideWidth;
 }
 
-prevButton.addEventListener("click", backward)
-    
-function backward(){
+nextButton.addEventListener("click", forward)
+
+function forward() {
   const slideWidth = slide.clientWidth;
   slidesContainer.scrollLeft += slideWidth;
-};
+}
 

--- a/spanish.html
+++ b/spanish.html
@@ -1,6 +1,6 @@
 ---
 layout: null
-title: iRodriguez — Identidad y Acceso · Automatización Segura
+title: iRodriguez — Ingeniería de Identidad y Accesos
 permalink: /spanish.html
 ---
 <!DOCTYPE html>
@@ -9,9 +9,9 @@ permalink: /spanish.html
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1"/>
     <link rel="shortcut icon" href="img/logo-dark.png" type="image/x-icon">
-    <title>iRodriguez — Identidad y Accesos · Automatización Segura</title>
+    <title>iRodriguez — Ingeniería de Identidad y Accesos</title>
     <meta name="author" content="Isidro Rodriguez"/>
-    <meta name="description" content="Isidro Rodriguez — Ingeniero en Identidad y Accesos. Escribo sobre automatización segura para pequeñas empresas. Pensamiento de IAM empresarial aplicado a n8n, agentes de IA y proliferación de SaaS."/>
+    <meta name="description" content="Isidro Rodriguez, ingeniero en identidad y accesos. Escribo sobre ciclo de vida de identidades, diseño de autenticación y cómo construir automatización de procesos que no termine convertida en una ruta de acceso sin dueño."/>
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -57,7 +57,7 @@ permalink: /spanish.html
             <a href="#about">Acerca de Mí</a>
           </li>
           <li>
-            <a href="#services">Experiencia</a>
+            <a href="#services">Especialización</a>
           </li>
           <li>
             <a href="#articles">Perspectivas</a>
@@ -79,10 +79,10 @@ permalink: /spanish.html
         <img class="owner-pic border" alt="Isidro's picture" src="img/me.png">
         <article class="description">
           <h1>Ing. Isidro Rodríguez</h1>
-          <p>He pasado 19 años como Ingeniero en Sistemas y la última década enfocado en Gestión de Identidad y Accesos (IAM) — más recientemente administrando Okta y construyendo automatizaciones no-code a la escala de Remitly.</p>
-          <p>La identidad es donde los sistemas se mantienen unidos o se desmoronan en silencio. La misma automatización que le ahorra 20 horas semanales a tu equipo está a una API key olvidada o a una cuenta de servicio sobre-privilegiada de convertirse en un titular.</p>
-          <p>La mayoría de las pequeñas empresas están adoptando IA y automatización sin que nadie en la sala haga las preguntas difíciles de seguridad. Las grandes empresas le pagan a gente como yo para hacer esas preguntas. Las pequeñas empresas no pueden — y no deberían tener que hacerlo.</p>
-          <p>Escribo sobre lo que la IAM empresarial hace bien, lo que las pequeñas empresas pueden tomar de ahí, y cómo construir automatizaciones que sobrevivan tanto a una auditoría como a una brecha.</p>
+          <p>Diecinueve años como ingeniero en sistemas, la última década en gestión de identidad y accesos. Mi trabajo diario está en proveedores de identidad corporativos a escala empresarial: políticas de autenticación, factores resistentes a phishing, el ciclo joiner-mover-leaver, cuentas de servicio y la automatización que sostiene todo eso. Okta Certified Professional.</p>
+          <p>La identidad es donde los sistemas se mantienen unidos o se desmoronan en silencio. La automatización que le ahorra veinte horas semanales a un equipo está a una API key olvidada de convertirse en el informe de incidente.</p>
+          <p>Casi todo lo que escribo parte de la misma observación. A las plataformas de automatización y a los agentes de IA se les están entregando credenciales más rápido de lo que alguien las gobierna. Un flujo de n8n con un token guardado es una cuenta de servicio. Un agente de código corriendo bajo la sesión de una persona es una identidad sin gestionar. El manual de IAM ya cubre esto. Solo que todavía nadie lo ha apuntado hacia allá.</p>
+          <p>De eso escribo: ingeniería de identidad, automatización del ciclo de vida y los puntos donde las dos se rompen en silencio.</p>
           <p><em>Opiniones firmes. Código funcional. Cero "fanboy" de proveedores.</em></p>
         </article>
         <button class="linkedin glass">
@@ -92,40 +92,39 @@ permalink: /spanish.html
       </section>
       <section id="services">
         <article class="services-content">
-          <h1>Experiencia.</h1>
-          <p>Pensamiento empresarial, a la medida de negocios en crecimiento. Ayudo a equipos pequeños y medianos a entender quién tiene acceso a qué, asegurarlo, y automatizar el trabajo aburrido sin abrir la puerta a una brecha. Los marcos vienen del mundo de IAM empresarial — PCI-DSS, HIPAA, GDPR, FISMA, Zero Trust, joiner-mover-leaver — pero las recomendaciones están calibradas a lo que una empresa de 10 a 200 personas puede realmente ejecutar.</p>
-          <p>El servicio principal — la Evaluación de Postura de Identidad Segura — está en desarrollo y se lanza en Q4 2026. Mientras tanto, sigue los artículos y el trabajo open-source a continuación.</p>
+          <h1>Especialización.</h1>
+          <p>Donde pasa mi tiempo. El hilo conductor es la identidad: qué puede alcanzar un sistema, cómo se otorga y se quita ese acceso, y cuánto de eso se puede automatizar sin perder la trazabilidad. Los marcos son los de siempre, privilegio mínimo y joiner-mover-leaver y Zero Trust, ISO 27001 y SOX y PCI DSS. Los problemas interesantes están siempre más abajo, en la implementación.</p>
         </article>
-        <button class="slide-arrow arrow-next">&#8249;</button>
-        <button class="slide-arrow arrow-prev">&#8250;</button>
+        <button class="slide-arrow arrow-prev">&#8249;</button>
+        <button class="slide-arrow arrow-next">&#8250;</button>
         <ul class="slides-container glass">
           <li class="slide border">
             <img src="img/risk.svg">
             <div>
-              <h2>Evaluación de Postura de Identidad Segura <em>(Próximamente Q4 2026)</em></h2>
+              <h2>Ciclo de Vida y Gobierno de Identidades</h2>
               <p>
-                <em>Descubre quién realmente tiene acceso a qué — antes de descubrirlo de la peor manera.</em>
-                Una auditoría corta y práctica de la configuración de identidad de tu negocio: quién puede iniciar sesión en qué, dónde viven las credenciales, qué pueden tocar tus automatizaciones, y cuáles 3 correcciones importarían más. Entregada como un reporte priorizado para actuar. Diseñado para empresas de 10–200 empleados con creciente complejidad de SaaS.
+                <em>Joiner-mover-leaver como problema de ingeniería, no como cola de tickets.</em>
+                Aprovisionamiento y desaprovisionamiento sobre SCIM, revisiones de acceso que producen evidencia en lugar de hojas de cálculo, y gobierno para esas cuentas de servicio que nadie recuerda haber creado. Otorgar el acceso es la mitad fácil. La difícil es demostrar que la baja ocurrió de verdad, dentro de la ventana que le prometiste al auditor.
               </p>
             </div>
           </li>
           <li class="slide border">
             <img src="img/cyber.svg">
             <div>
-              <h2>Estrategia de Identidad y Accesos para Negocios en Crecimiento</h2>
+              <h2>Diseño de Autenticación y Accesos</h2>
               <p>
-                <em>Pensamiento de IAM empresarial, a la medida de tu negocio.</em>
-                Los marcos que las grandes empresas usan para gestionar quién tiene acceso a qué — joiner-mover-leaver, privilegio mínimo, Zero Trust — traducidos a las decisiones prácticas que necesita tomar una empresa de 30 personas. Estrategia, no ventas de proveedores.
+                <em>Política, factores y privilegio, en el orden en que tienen que ocurrir.</em>
+                Políticas de autenticación, factores resistentes a phishing, accesos privilegiados y los patrones Zero Trust de NIST 800-207 aplicados a entornos que ya existen y no pueden dejar de funcionar. Mover a toda una plantilla fuera de contraseñas y SMS es menos una decisión técnica que una de secuencia, y la secuencia es donde se atascan casi todos los despliegues.
               </p>
             </div>
           </li>
           <li class="slide border">
             <img src="img/appdev.svg">
             <div>
-              <h2>Automatizaciones Seguras <em>(n8n + IA)</em></h2>
+              <h2>Automatización Con Modelo de Identidad <em>(n8n, Okta Workflows, agentes de IA)</em></h2>
               <p>
-                <em>Automatiza el trabajo aburrido — sin abrir la puerta a una brecha de seguridad.</em>
-                Flujos de trabajo personalizados en n8n y con agentes de IA, diseñados con seguridad empresarial desde el primer día: credenciales con alcance limitado, registros de auditoría, cuentas de servicio con privilegio mínimo, y rotación incluida. El tipo de automatización que sobrevive tanto a una auditoría como a un incidente a las 3am.
+                <em>Todo flujo guarda una credencial, y eso convierte a todo flujo en una identidad.</em>
+                Automatización de procesos construida con credenciales de alcance limitado, rotación y registro de auditoría desde la primera versión y no desde la tercera. Tratar un flujo como una identidad es toda la diferencia entre una automatización y una ruta de acceso que nadie está mirando, y cuesta casi nada si se hace desde el inicio.
               </p>
             </div>
           </li>
@@ -133,7 +132,7 @@ permalink: /spanish.html
       </section>
       <section id="articles">
         <h1>Perspectivas.</h1>
-        <p>Nuevo contenido sobre Gestión de Identidad y Accesos y automatización segura está en camino. A continuación, ensayos anteriores sobre fundamentos de ciberseguridad — marcos del NIST, panorama de amenazas, y lo básico que todo negocio en crecimiento debería entender antes de empezar la conversación sobre IAM.</p>
+        <p>Escritos sobre ingeniería de identidad, automatización del ciclo de vida y las preguntas de seguridad que se saltan cuando la automatización avanza más rápido que el gobierno. Los ensayos más antiguos cubren fundamentos, NIST CSF y el RMF y los ocho dominios, que siguen siendo la base de todo lo que viene después.</p>
         <div class="article-grid">
           {% assign posts_es = site.posts_sp %}
           {% for post in posts_es %}
@@ -149,7 +148,7 @@ permalink: /spanish.html
       <section id="contact" class="contact-section glass">
         <div class="contact-intro">
           <h2 class="contact-title">Contacto.</h2>
-          <p class="contact-description">Escríbeme sobre IAM, automatización segura, charlas o colaboraciones. Leo cada mensaje — respondo lo más pronto posible.</p>
+          <p class="contact-description">Dudas sobre ingeniería de identidad o automatización, invitaciones a charlas y podcasts, o un comentario sobre algo que escribí. Leo todo y respondo cuando puedo.</p>
         </div>
         <form class="contact-form" action="https://api.web3forms.com/submit" method="POST">
           <input type="hidden" name="access_key" value="0930297a-ed42-4661-8532-7e6227a284f7"/>
@@ -163,10 +162,6 @@ permalink: /spanish.html
             <div class="form-group">
               <label for="email" class="form-label">Correo Electrónico</label>
               <input id="email" name="email" class="form-input" placeholder="ejemplo@dominio.com" type="email"/>
-            </div>
-            <div class="form-group">
-              <label for="phone" class="form-label">Teléfono</label>
-              <input id="phone" name="phone" class="form-input" placeholder="+505 (1234) 5678" type="text"/>
             </div>
             <div class="form-group">
               <label for="message" class="form-label">Mensaje</label>


### PR DESCRIPTION
## Why

The site was written as a consultancy funnel: three productized offers, a flagship service with a Q4 2026 launch date, target-customer sizing, and a phone field on the contact form. The intent is professional authority, not client acquisition, so the positioning needed a rework rather than a copy polish.

## Copy

- **Expertise** goes from three service offers to three expertise domains (Identity Lifecycle and Governance / Authentication and Access Design / Automation With an Identity Model). No pricing, deliverables, company-size targeting, or launch dates.
- **About** drops the "enterprises pay people like me / small businesses can't" pitch in favour of a thesis on unmanaged automation identities. Adds Okta Certified Professional.
- **All employer references removed.**
- **Perspectives** intro was stale: it claimed IAM writing was "on the way" while five 2026 posts sat underneath it.
- **Contact** reframed away from lead capture; phone field removed from both forms.
- Hero typewriter lines replaced in both languages. Page titles, meta descriptions, and the site-wide `_config.yml` description rewritten.
- Human pass throughout: em-dash emphasis, negative parallelism, and rule-of-three padding cut.
- Dropped the "follow the open-source work below" claim; there is no such section.

Spanish is a parallel rewrite, not a translation. `Experiencia` became `Especialización` in both the nav and the heading, since the former reads as work history.

## UI

- `footer` is a flex column with a `1.5rem` gap so the portrait no longer touches the tagline. `.decoLine` moved `40% -> 35%` to keep the rule crossing the portrait rather than the face after the height change.
- Carousel arrows moved from the centre of the section to its left and right edges, vertically centred.
- Carousel controls renamed to match behaviour: `.arrow-prev` is the left `<` that scrolls back, `.arrow-next` the right `>` that advances. Previously inverted. Also fixes the `foward()` spelling.

## Not addressed

Jekyll has never been installed locally (no `Gemfile.lock`, system Ruby 2.6.10), so this was reviewed as raw HTML via Live Server. Liquid-rendered output is unverified locally and relies on the Pages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)